### PR TITLE
Support for modular applications`

### DIFF
--- a/lib/sinatra/static_assets.rb
+++ b/lib/sinatra/static_assets.rb
@@ -86,7 +86,7 @@ module Sinatra
       end
 
       def source_url_timestamp(url)
-        full_url = "#{Sinatra::Application.root}/public#{url}"
+        full_url = "#{settings.root}/public#{url}"
         if File.exists? full_url
           timestamp = File.mtime(full_url).to_i
           "#{url}?#{timestamp}"

--- a/test/sinatra_static_assets_test.rb
+++ b/test/sinatra_static_assets_test.rb
@@ -57,7 +57,7 @@ EOD
   end
 
   def test_tags_returns_time_stamp_when_file_exists
-    file_path = "#{Sinatra::Application.root}/public/bar/javascripts/summer.js"
+    file_path = "#{app.settings.root}/public/bar/javascripts/summer.js"
     File.expects(:"exists?").with(file_path).returns(true)
     File.expects(:mtime).with(file_path).returns(123456789)
 


### PR DESCRIPTION
The hardcoded `Sinatra::Application.root` in the cachebuster was messing up my modular Sinatra app. This uses `settings.root` instead.
